### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://am9llc.visualstudio.com/b4550bc3-a4ee-45e4-b509-6f0813b1e6f2/a7ebb533-9ec0-4bbc-b317-ffc28fa65b69/_apis/work/boardbadge/efa0438f-166d-4323-bb20-fdccb096868a)](https://am9llc.visualstudio.com/b4550bc3-a4ee-45e4-b509-6f0813b1e6f2/_boards/board/t/a7ebb533-9ec0-4bbc-b317-ffc28fa65b69/Microsoft.RequirementCategory)
 # WebApp
 Code Repo for WebApp Development- Monolith Architecture


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://am9llc.visualstudio.com/b4550bc3-a4ee-45e4-b509-6f0813b1e6f2/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.